### PR TITLE
fix: ensure we have a current list of top-sections for search_index

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -175,7 +175,7 @@ class format_flexsections extends core_courseformat\base {
             // Show weeks layout for top level section.
             if (isset($section->parent) && $section->parent === 0) {
                 // This is identical what weekly format does.
-                $dates = $this->get_section_dates($section);
+                $dates = $this->get_section_dates($section, resettopsections: true);
 
                 // We subtract 24 hours for display purposes.
                 $dates->end = ($dates->end - DAYSECS);


### PR DESCRIPTION
Workaround, because search index kept running into 'get_section_dates method is designed to be used with top level sections only.' exception, because the list of top_sections was out of date and missing some sections.


```php
            $offset = array_search($sectionnum, $topsections);  
            if ($offset === false) { 
                // Supplied section is not a top section. 
                 var_dump("section-parent: ". $section->parent); 
                 var_dump("section-id: ". $section->id); 
                 var_dump("sectionnum" . $sectionnum); 
                 var_dump($topsections); 
                 throw new coding_exception('get_section_dates method is designed to be used with top level sections only.'); 
            } 
    
``` 
```php 
            // Show weeks layout for top level section. 
            if (isset($section->parent) && $section->parent === 0) { 
                var_dump("parent, after if, before date:" . $section->parent);     
                // This is identical what weekly format does. 
                // $dates = $this->get_section_dates($section); 
                $dates = $this->get_section_dates($section, resettopsections: True); 
                // We subtract 24 hours for display purposes. 
                $dates->end = ($dates->end - DAYSECS); 
 
                $dateformat = get_string('strftimedateshort'); 
                $weekday = userdate($dates->start, $dateformat); 
                $endweekday = userdate($dates->end, $dateformat); 
                return $weekday.' - '.$endweekday; 
            } else {
``` 


```
string(31) "parent, after if, before date: 0"
string(31) "parent, after if, before date: 0"
string(17) "section-parent: 0"
string(18) "section-id: 605715"
string(12) "sectionnum: 31"
array(20) {
  [0]=>
  int(0)
  [1]=>
  int(1)
  [2]=>
  int(5)
  [3]=>
  int(9)
  [4]=>
  int(12)
  [5]=>
  int(16)
  [6]=>
  int(19)
  [7]=>
  int(22)
  [8]=>
  int(23)
  [9]=>
  int(24)
  [10]=>
  int(25)
  [11]=>
  int(26)
  [12]=>
  int(27)
  [13]=>
  int(30)
  [14]=>
  int(33)
  [15]=>
  int(36)
  [16]=>
  int(37)
  [17]=>
  int(38)
  [18]=>
  int(41)
  [19]=>
  int(42)
}
... used 288 dbqueries
... used 0.62990689277649 seconds
Scheduled task failed: Indizierung für die globale Suche (core\task\search_index_task),Fehler in der Kodierung gefunden, den nur Programmierer/innen korrigieren können: get_section_dates method is designed to be used with top level sections only.
Backtrace:
```